### PR TITLE
Refactor `Compositor`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Compositor"]
 	path = Compositor
 	url = https://github.com/Avdan-OS/Compositor.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Compositor"]
+	path = Compositor
+	url = https://github.com/Avdan-OS/Compositor.git


### PR DESCRIPTION
Move all compositor work to [`Avdan-OS/Compositor`](https://github.com/Avdan-OS/Compositor),
the submodule on `Desktop-Environment/main` will then track `Compositor/main`.

I have already set the same set-up for `Desktop-Environment/dev` and `Compositor/dev`.  

This would be part of solving #34.